### PR TITLE
Release 0.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+#!make
+.EXPORT_ALL_VARIABLES:
+-include .env
+
+up:
+	docker-compose up --build
+
+up_dev:
+	docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,7 @@
+version: '3.2'
+services:
+  rcspy:
+    restart: "no"
+    volumes:
+      - .:/app
+      - ./cache:/app/cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
-version: '3.2'
+version: '3.7'
 services:
-  rcspy:
-    build: .
-    image: rcspy
-    container_name: rcspy
+  cacheserver:
+    build: 
+      context: .
+    image: experius/seosnap-cacheserver
+    container_name: cacheserver
     restart: always
     environment:
       RENDERTRON_CACHE_DEBUG:
@@ -19,8 +20,7 @@ services:
       - ./cache:/app/cache
     ports:
       - 5000:5000
-    env_file:
-      - .env.docker
+    env_file: .env.docker
     networks:
       - rendertron_net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,11 @@ services:
       - rendertron_net
 
   rendertron:
-    image: egordm/rendertron
+    image: egordm/rendertron:latest
     container_name: rendertron
     restart: always
+    volumes:
+      - ./rendertron-config.json:/app/config.json
     ports:
       - 3000:3000
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       RENDERTRON_CACHE_HEADER_REQUEST_BLACKLIST:
       RENDERTRON_CACHE_HEADER_RESPONSE_BLACKLIST:
     volumes:
-      - .:/app
       - ./cache:/app/cache
     ports:
       - 5000:5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,17 @@
 version: '3.2'
 services:
   rcspy:
-    build:
-      context: .
+    build: .
     image: rcspy
     container_name: rcspy
     restart: always
+    volumes:
+      - .:/app
+      - ./cache:/app/cache
     ports:
       - 5000:5000
     env_file:
       - .env.docker
-    volumes:
-      - .:/app
-      - ./cache:/app/cache
     networks:
       - rendertron_net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,15 @@ services:
     image: rcspy
     container_name: rcspy
     restart: always
+    environment:
+      RENDERTRON_CACHE_DEBUG:
+      RENDERTRON_CACHE_LOCK_TIMEOUT:
+      RENDERTRON_CACHE_ROOT:
+      RENDERTRON_CACHE_FILE_SUFFIX:
+      RENDERTRON_CACHE_RESOURCE_URL:
+      RENDERTRON_CACHE_RESOURCE_METHOD:
+      RENDERTRON_CACHE_HEADER_REQUEST_BLACKLIST:
+      RENDERTRON_CACHE_HEADER_RESPONSE_BLACKLIST:
     volumes:
       - .:/app
       - ./cache:/app/cache

--- a/rendertron-config.json
+++ b/rendertron-config.json
@@ -1,0 +1,3 @@
+{
+  "restrictedUrlPattern": ".*(\\.png|\\.jpg|\\.jpeg|\\.gif|\\.webp|\\.mp4)($|\\?)"
+}


### PR DESCRIPTION
# Release 0.3.0
## Cache Server
* Restricted rendertron from downloading images by default (see rendertron-config.json)
* Split docker compose into general use and development versions